### PR TITLE
Latest npm versions save by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
  
  ### Install
  
- * ``` npm install use-reducer-with-side-effects --save```
+ * ``` npm install use-reducer-with-side-effects```
  * ``` yarn add use-reducer-with-side-effects```
 
 ### Exports


### PR DESCRIPTION
Just a lil readme update. As of npm v5 (which is 2.5 years old), `--save` is the default behavior when doing an `npm install`