### PR TITLE
Update React peerDependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "@babel/core": "^7.4.5"
   },
   "peerDependencies": {
-    "react": "16.8.x"
+    "react": "^16.8.0"
   }
 }


### PR DESCRIPTION
This updates this lib's package.json to be compatible with React 16.9 as well as any other non-breaking releases to React.