### PR TITLE
fix(deps): move React from deps to devDeps to not bundle it in

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,10 @@
     "@babel/register": "latest",
     "proxyquire": "^2.1.3",
     "tap-diff": "^0.1.1",
-    "tape": "^4.11.0"
+    "tape": "^4.11.0",
+    "react": "^16.9.0"
   },
   "peerDependencies": {
     "react": "^16.8.0"
-  },
-  "dependencies": {
-    "react": "^16.9.0"
   }
 }


### PR DESCRIPTION
This just makes it so that using this package doesn't accidentally bring in React 16.9, even when technically the peerDep says 16.8